### PR TITLE
:sparkles: use 'backport' instead of 'cherry-pick'

### DIFF
--- a/.github/workflows/cherry-pick.yaml
+++ b/.github/workflows/cherry-pick.yaml
@@ -23,8 +23,8 @@ jobs:
             const labels = issue.labels.map(label => label.name);
             console.log(`Labels: ${labels}`);
 
-            const branches = labels.filter(label => label.startsWith('cherry-pick/'))
-              .map(label => label.substr(12));
+            const branches = labels.filter(label => label.startsWith('backport '))
+              .map(label => label.substr(9));
             console.log(`Branches: ${branches}`);
 
             return branches
@@ -54,6 +54,4 @@ jobs:
         uses: korthout/backport-action@v3
         with:
           github_token: ${{ steps.get_workflow_token.outputs.token }}
-          label_pattern: >-
-            ^cherry-pick\/([^ ]+)$
           pull_title: '${pull_title} [Backport ${target_branch}]'

--- a/pkg/config/config.yaml
+++ b/pkg/config/config.yaml
@@ -96,7 +96,7 @@ labels:
   # CherryPick
   - color: fef2a0
     description: This PR should be cherry-picked to release/0.2.z branch.
-    name: cherry-pick/release/0.2.z
+    name: backport release/0.2.z
 
 # Milestones
 # List of milestones, and their state, that should exist in the specified repositories.


### PR DESCRIPTION
This change will apply to both the cherry-pick.yaml and the config.yaml so the change is consistent